### PR TITLE
An → A

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ If you want to use Pss APIs, you should first [install](https://swarm-guide.read
 
 Erebos can be used both in node and browser environments, and comes in different flavours:
 
-- An "universal" library when using `@erebos/swarm`, assuming you use a tool such as [webpack](https://webpack.js.org/) to bundle your assets.
+- A "universal" library when using `@erebos/swarm`, assuming you use a tool such as [webpack](https://webpack.js.org/) to bundle your assets.
 - A node-only library using `@erebos/swarm-node`.
 - A browser-only library using `@erebos/swarm-browser`.
 


### PR DESCRIPTION
I wasn't sure myself so I googled it and came across [this.](http://www.bbc.co.uk/worldservice/learningenglish/language/askaboutenglish/2010/06/100622_aae_indefinite_articles_pron.shtml)

The relevant excerpt:
> However, the rule that I just described should really be that you use ‘a’ before a word that begins with a consonant sound, and ‘an’ before a word that begins with a vowel sound. This means that the important thing is not how we spell and write the word, but how we say the word.
> So, with regard to the word ‘university’, the initial sound is actually the consonant sound /j/, so we say ‘a university’. If we look at your original question, the word ‘LP’ begins with a vowel sound, /e/. That is why we say ‘an LP’.