### PR TITLE
Remove unnecessary network flag from the start swarm script

### DIFF
--- a/start_swarm_node.sh
+++ b/start_swarm_node.sh
@@ -5,7 +5,6 @@ docker run \
        --env DATADIR=/data \
        --env PASSWORD=password123 \
        --volume /tmp/swarm-data:/data \
-       --network host \
        --interactive \
        --tty \
        "ethdevops/swarm:v0.3.11" \


### PR DESCRIPTION
@PaulLeCam I confirmed that this is unnecessary on Linux machines, it's a leftover from the CI setup.