### PR TITLE
Add support for `bzz-feed-raw` scheme

### DIFF
--- a/__tests__/api-bzz-node.ts
+++ b/__tests__/api-bzz-node.ts
@@ -10,7 +10,12 @@ import * as fs from 'fs-extra'
 import { Subject } from 'rxjs'
 import * as tar from 'tar-stream'
 
-import { Bzz, DirectoryEntry, ListEntry } from '@erebos/api-bzz-node'
+import {
+  Bzz,
+  DirectoryEntry,
+  ListEntry,
+  FEED_ZERO_TOPIC,
+} from '@erebos/api-bzz-node'
 import { hexValue } from '@erebos/hex'
 import { pubKeyToAddress } from '@erebos/keccak256'
 import { createKeyPair, sign } from '@erebos/secp256k1'
@@ -554,6 +559,26 @@ describe('api-bzz-node', () => {
       contentType: 'text/plain',
     })
     const res = await bzz.getFeedContent(feedParams)
+    const text = await res.text()
+    expect(text).toBe('hello')
+  })
+
+  it('sets and gets the raw feed content hash', async () => {
+    const feedParams = { user, topic: FEED_ZERO_TOPIC, time: 0, level: 0 }
+    const uploadedHash = await bzz.upload('hello', {
+      contentType: 'text/plain',
+    })
+    await bzz.setRawFeedContentHash(feedParams, uploadedHash)
+    const contentHash = await bzz.getRawFeedContentHash(feedParams)
+    expect(contentHash).toBe(uploadedHash)
+  })
+
+  it('sets and gets the raw feed content', async () => {
+    const feedParams = { user, topic: FEED_ZERO_TOPIC, time: 0, level: 0 }
+    await bzz.setRawFeedContent(feedParams, 'hello', {
+      contentType: 'text/plain',
+    })
+    const res = await bzz.getRawFeedContent(feedParams)
     const text = await res.text()
     expect(text).toBe('hello')
   })

--- a/docs/api-bzz.md
+++ b/docs/api-bzz.md
@@ -633,6 +633,60 @@ This method implements the flow of uploading the provided `data` and updating th
 
 **Returns** `Promise<string>`
 
+## Raw feed functionality
+
+Raw feeds can be used to skip Swarm's builtin feed lookup mechanism and use the underlying resource interface directly. Internally Swarm uses a separate address space for `bzz-feed`s and they can be addressed with `FeedParams`. When uploading content, a node calculates the hash from the `FeedParams` and stores the content so that it can be acccessed with that hash.
+
+As with the normal feed API we can only store one chunk worth of data (4KB) in a feed chunk, so the best practice is to store a content hash in the feed chunk. Sometimes it can be useful to work directly with the content hashes and sometimes we just need the content. Hence we have two versions of each function when downloading or uploading the data.
+
+### .getRawFeedContentHash()
+
+This method downloads the hash that can be found on the address specified by the `FeedParams`.
+
+**Arguments**
+
+1.  `params: FeedParams` [feed parameters](#feedparams)
+1.  [`options?: FetchOptions = {}`](#fetchoptions)
+
+**Returns** `Promise<string>`
+
+### .getRawFeedContent()
+
+This method downloads the contents of the hash that can be found on the address specified by the `FeedParams`.
+
+**Arguments**
+
+1.  `params: FeedParams` [feed parameters](#feedparams)
+1.  [`options?: DownloadOptions = {}`](#downloadoptions)
+
+**Returns** `Promise<Response>`
+
+### .setRawFeedContentHash()
+
+This method uploads a hash to the raw feed that can be found on the address specified by the `FeedParams`.
+
+**Arguments**
+
+1.  `params: FeedParams` [feed parameters](#feedparams)
+1.  `contentHash: string`
+1.  [`options?: UploadOptions = {}`](#uploadoptions)
+1.  `signParams?: any`
+
+**Returns** `Promise<Response>`
+
+### .setRawFeedContent()
+
+This method implements the flow of uploading the provided `data` and updating the raw feed identified by the provided `FeedParams` with the immutable hash of the uploaded contents, and returns this hash.
+
+**Arguments**
+
+1.  `params: FeedParams` [feed parameters](#feedparams)
+1.  `data: string | Buffer | DirectoryData`
+1.  [`options?: UploadOptions = {}`](#uploadoptions)
+1.  `signParams?: any`
+
+**Returns** `Promise<hexValue>`
+
 ### .pin()
 
 Pins the specified resource. To make sure the resource is available on the node, the `download` option can be set to explicitely download it before pinning.

--- a/packages/api-bzz-base/src/feed.ts
+++ b/packages/api-bzz-base/src/feed.ts
@@ -18,6 +18,8 @@ const FEED_PARAMS_LENGTH =
 
 const FEED_SIGNATURE_LENGTH = 65
 
+export const FEED_ZERO_TOPIC: hexValue = '0x0000000000000000000000000000000000000000000000000000000000000000' as hexValue
+
 export function createFeedDigest(
   meta: FeedMetadata,
   data: hexInput,
@@ -101,10 +103,21 @@ export function feedChunkToData(chunkData: ArrayBuffer): ArrayBuffer {
     throw new Error('Invalid chunk data length')
   }
 
-  const buffer = Buffer.from(
-    chunkData,
-    FEED_PARAMS_LENGTH,
-    chunkData.byteLength - FEED_PARAMS_LENGTH - FEED_SIGNATURE_LENGTH,
-  )
-  return buffer
+  const length =
+    chunkData.byteLength - FEED_PARAMS_LENGTH - FEED_SIGNATURE_LENGTH
+  return chunkData.slice(FEED_PARAMS_LENGTH, FEED_PARAMS_LENGTH + length)
+}
+
+export function feedParamsToMetadata(params: FeedParams): FeedMetadata {
+  return {
+    feed: {
+      user: toHexValue(params.user),
+      topic: params.topic != null ? toHexValue(params.topic) : FEED_ZERO_TOPIC,
+    },
+    epoch: {
+      time: params.time != null ? params.time : 0,
+      level: params.level != null ? params.level : 0,
+    },
+    protocolVersion: 0,
+  }
 }

--- a/packages/api-bzz-base/src/feed.ts
+++ b/packages/api-bzz-base/src/feed.ts
@@ -1,13 +1,22 @@
 import { createHex, hexInput, hexValue, toHexValue } from '@erebos/hex'
 import { hash } from '@erebos/keccak256'
 
-import { FeedMetadata, FeedTopicParams } from './types'
+import { FeedMetadata, FeedTopicParams, FeedParams } from './types'
 
 const FEED_TOPIC_LENGTH = 32
 const FEED_USER_LENGTH = 20
 const FEED_TIME_LENGTH = 7
 const FEED_LEVEL_LENGTH = 1
 const FEED_HEADER_LENGTH = 8
+
+const FEED_PARAMS_LENGTH =
+  FEED_TOPIC_LENGTH +
+  FEED_USER_LENGTH +
+  FEED_TIME_LENGTH +
+  FEED_LEVEL_LENGTH +
+  FEED_HEADER_LENGTH
+
+const FEED_SIGNATURE_LENGTH = 65
 
 export function createFeedDigest(
   meta: FeedMetadata,
@@ -52,4 +61,50 @@ export function getFeedTopic(params: FeedTopicParams): hexValue {
     .fill(0)
     .map((_, i) => topic[i] ^ name[i])
   return toHexValue(bytes)
+}
+
+export function feedParamsToReference(params: FeedParams): hexValue {
+  if (params.topic == null) {
+    throw new Error('Invalid topic')
+  }
+  const topicBuffer = createHex(params.topic).toBuffer()
+  if (topicBuffer.length !== FEED_TOPIC_LENGTH) {
+    throw new Error('Invalid topic length')
+  }
+  const userBuffer = createHex(params.user).toBuffer()
+  if (userBuffer.length !== FEED_USER_LENGTH) {
+    throw new Error('Invalid user length')
+  }
+
+  if (params.time == null) {
+    throw new Error('Invalid time')
+  }
+  const timeBuffer = Buffer.alloc(FEED_TIME_LENGTH, 0)
+  timeBuffer.writeUInt32LE(params.time, 0)
+  if (params.level == null) {
+    throw new Error('Invalid level')
+  }
+  const levelBuffer = Buffer.alloc(FEED_LEVEL_LENGTH, 0)
+  levelBuffer.writeUInt8(params.level, 0)
+
+  const payload = Buffer.concat([
+    topicBuffer,
+    userBuffer,
+    timeBuffer,
+    levelBuffer,
+  ])
+  return toHexValue(hash(payload))
+}
+
+export function feedChunkToData(chunkData: ArrayBuffer): ArrayBuffer {
+  if (chunkData.byteLength <= FEED_PARAMS_LENGTH + FEED_SIGNATURE_LENGTH) {
+    throw new Error('Invalid chunk data length')
+  }
+
+  const buffer = Buffer.from(
+    chunkData,
+    FEED_PARAMS_LENGTH,
+    chunkData.byteLength - FEED_PARAMS_LENGTH - FEED_SIGNATURE_LENGTH,
+  )
+  return buffer
 }

--- a/packages/api-bzz-base/src/index.ts
+++ b/packages/api-bzz-base/src/index.ts
@@ -722,14 +722,14 @@ export class BaseBzz<
     return response
   }
 
-  public async getRawFeedData(params: FeedParams): Promise<ArrayBuffer> {
+  public async getRawFeedContent(params: FeedParams): Promise<ArrayBuffer> {
     const response = await this.fetchRawFeedChunk(params)
     const dataBuffer = await response.arrayBuffer()
     return feedChunkToData(dataBuffer)
   }
 
   public async getRawFeedContentHash(params: FeedParams): Promise<string> {
-    const dataBuffer = await this.getRawFeedData(params)
+    const dataBuffer = await this.getRawFeedContent(params)
     return Buffer.from(dataBuffer).toString('hex')
   }
 

--- a/packages/api-bzz-base/types/feed.d.ts
+++ b/packages/api-bzz-base/types/feed.d.ts
@@ -1,4 +1,8 @@
 import { hexInput, hexValue } from '@erebos/hex';
-import { FeedMetadata, FeedTopicParams } from './types';
+import { FeedMetadata, FeedTopicParams, FeedParams } from './types';
+export declare const FEED_ZERO_TOPIC: hexValue;
 export declare function createFeedDigest(meta: FeedMetadata, data: hexInput): Array<number>;
 export declare function getFeedTopic(params: FeedTopicParams): hexValue;
+export declare function feedParamsToReference(params: FeedParams): hexValue;
+export declare function feedChunkToData(chunkData: ArrayBuffer): ArrayBuffer;
+export declare function feedParamsToMetadata(params: FeedParams): FeedMetadata;

--- a/packages/api-bzz-base/types/index.d.ts
+++ b/packages/api-bzz-base/types/index.d.ts
@@ -70,4 +70,10 @@ export declare class BaseBzz<Response extends BaseResponse, Readable extends str
     pins(options?: FetchOptions): Promise<Array<PinnedFile>>;
     getTag(hash: string, options?: FetchOptions): Promise<Tag>;
     pollTag(hash: string, options: PollOptions): Observable<Tag>;
+    private getRawFeedChunk;
+    private getRawFeedChunkData;
+    getRawFeedContentHash(params: FeedParams, options?: FetchOptions): Promise<string>;
+    getRawFeedContent(params: FeedParams, options?: DownloadOptions): Promise<Response>;
+    setRawFeedContentHash(params: FeedParams, contentHash: string, options?: UploadOptions, signParams?: any): Promise<Response>;
+    setRawFeedContent(params: FeedParams, data: string | Buffer | DirectoryData, options?: UploadOptions, signParams?: any): Promise<hexValue>;
 }

--- a/packages/api-bzz-base/types/index.d.ts
+++ b/packages/api-bzz-base/types/index.d.ts
@@ -8,6 +8,7 @@ export * from './types';
 export declare const BZZ_MODE_PROTOCOLS: {
     default: string;
     feed: string;
+    feedRaw: string;
     immutable: string;
     pin: string;
     raw: string;


### PR DESCRIPTION
Raw feeds can be used to skip Swarm's builtin feed lookup mechanism and use the underlying resource interface directly. Internally Swarm uses a separate address space for `bzz-feed`s and they can be addressed by a `(user, topic, level, time)` tuple. When uploading content, a node calculates the hash from the tuple and stores the content so that it can be acccessed with that hash (therefore `bzz-feed`s are not content addressed). With the new `bzz-feed-raw` scheme it becomes possible to retrieve the content the same way directly. This can be used for example to store an incremental history of data, indexed by the time field incrementally and then looking up if there is new data can be just one chunk lookup instead of many, like it is with the standard feeds interface. 

This PR adds functions for uploading and downloading data to raw feeds, similarly how feeds are used. The most common use case is to store the content hash in a raw feed (`get/setRawFeedContentHash`) but any other data can be stored directly as well. (`get/setRawFeedContent`). Unlike with feeds the functions for fetching chunks are not exposed publicly in the API, because the raw chunks contain Swarm specific data before and after the user provided data that may be subject to change in the future and also I didn't find a use-case for using them.

