### PR TITLE
feat: expose error messages

### DIFF
--- a/__tests__/api-bzz-base.ts
+++ b/__tests__/api-bzz-base.ts
@@ -56,20 +56,22 @@ describe('api-bzz-base', () => {
     expect(error.status).toBe(404)
   })
 
-  it('exports resOrError() utility function', () => {
+  it('exports resOrError() utility function', async () => {
     const resOK = { ok: true }
-    expect(resOrError(resOK)).toBe(resOK)
+    expect(await resOrError(resOK)).toBe(resOK)
 
     try {
-      resOrError({
+      await resOrError({
         ok: false,
         status: 400,
+        text: (): Promise<string> =>
+          Promise.resolve('Message: Some error message'),
         statusText: 'Bad request',
       })
     } catch (error) {
       expect(error instanceof HTTPError).toBe(true)
       expect(error.status).toBe(400)
-      expect(error.message).toBe('Bad request')
+      expect(error.message).toBe('Some error message')
     }
   })
 
@@ -84,12 +86,14 @@ describe('api-bzz-base', () => {
       await resJSON({
         ok: false,
         status: 400,
+        text: (): Promise<string> =>
+          Promise.resolve('Message: Some error message'),
         statusText: 'Bad request',
       })
     } catch (error) {
       expect(error instanceof HTTPError).toBe(true)
       expect(error.status).toBe(400)
-      expect(error.message).toBe('Bad request')
+      expect(error.message).toBe('Some error message')
     }
   })
 
@@ -104,12 +108,14 @@ describe('api-bzz-base', () => {
       await resText({
         ok: false,
         status: 400,
+        text: (): Promise<string> =>
+          Promise.resolve('Message: Some error message'),
         statusText: 'Bad request',
       })
     } catch (error) {
       expect(error instanceof HTTPError).toBe(true)
       expect(error.status).toBe(400)
-      expect(error.message).toBe('Bad request')
+      expect(error.message).toBe('Some error message')
     }
   })
 

--- a/__tests__/browser.ts
+++ b/__tests__/browser.ts
@@ -84,10 +84,10 @@ describe('browser', () => {
         try {
           await client.bzz.download('abcdef123456')
         } catch (err) {
-          return err.message
+          return err.status
         }
       })
-      expect(errMessage).toBe('Not Found')
+      expect(errMessage).toBe(404)
     })
 
     it('uploads/downloads the file using bzz', async () => {

--- a/packages/api-bzz-base/types/index.d.ts
+++ b/packages/api-bzz-base/types/index.d.ts
@@ -19,9 +19,9 @@ export declare class HTTPError extends Error {
     status: number;
     constructor(status: number, message: string);
 }
-export declare function resOrError<R extends BaseResponse>(res: R): R;
+export declare function resOrError<R extends BaseResponse>(res: R): Promise<R>;
 export declare function resJSON<R extends BaseResponse, T = any>(res: R): Promise<T>;
-export declare function resStream<R extends BaseResponse<stream.Readable>, T = any>(res: R): stream.Readable | ReadableStream;
+export declare function resStream<R extends BaseResponse<stream.Readable>, T = any>(res: R): Promise<stream.Readable | ReadableStream>;
 export declare function resText<R extends BaseResponse>(res: R): Promise<string>;
 export declare function resHex<R extends BaseResponse>(res: R): Promise<hexValue>;
 export declare function resSwarmHash<R extends BaseResponse>(res: R): Promise<string>;


### PR DESCRIPTION
This patch exposes error messages returned from Swarm.

Instead "Bad Request" you now get for example "expected set Content-length".