### PR TITLE
Fix for big data download of Directory

### DIFF
--- a/docs/swarm-client.md
+++ b/docs/swarm-client.md
@@ -4,12 +4,33 @@ title: Swarm client
 
 The Erebos `SwarmClient` class provides an unified way of interacting with the Swarm APIs based on a provided configuration, or simply a server endpoint.
 
-```javascript
-import { SwarmClient } from '@erebos/swarm-browser' // browser
-// or
-import { SwarmClient } from '@erebos/swarm-node' // node
-// or
-import { SwarmClient } from '@erebos/swarm' // universal
+## Installation
+
+### For browser
+
+```sh
+npm install @erebos/swarm-browser
+```
+
+You can load this module also directly as bundle using a script tag, which will make `Erebos.swarm` object available
+through global namespace:
+
+```html
+<script src="https://unpkg.com/@erebos/swarm-browser/dist/erebos.swarm.production.js"></script>
+```
+        
+This bundle expose `Buffer` and `Readable` under the `Erebos.swarm` object.
+
+### For Node
+
+```sh
+npm install @erebos/swarm-node
+```
+
+### Universal
+
+```sh
+npm install @erebos/swarm
 ```
 
 ## RPC class

--- a/packages/api-bzz-browser/src/utils.ts
+++ b/packages/api-bzz-browser/src/utils.ts
@@ -39,7 +39,6 @@ export class NodeReadable extends Readable {
           return doRead()
         } else {
           this._reading = false
-          this._reader.releaseLock()
         }
       })
     }

--- a/packages/swarm-browser/src/index.ts
+++ b/packages/swarm-browser/src/index.ts
@@ -15,6 +15,10 @@ export { Pss } from '@erebos/api-pss'
 export { Hex, createHex } from '@erebos/hex'
 export { createRPC } from '@erebos/rpc-browser'
 
+// Exporting internal tooling that might be handy
+export { Buffer } from 'buffer'
+export { Readable } from 'readable-stream'
+
 export interface SwarmConfig extends ClientConfig {
   bzz?: BzzConfig | Bzz
   pss?: string | Pss

--- a/packages/swarm-browser/types/index.d.ts
+++ b/packages/swarm-browser/types/index.d.ts
@@ -6,6 +6,8 @@ export { Bzz } from '@erebos/api-bzz-browser';
 export { Pss } from '@erebos/api-pss';
 export { Hex, createHex } from '@erebos/hex';
 export { createRPC } from '@erebos/rpc-browser';
+export { Buffer } from 'buffer';
+export { Readable } from 'readable-stream';
 export interface SwarmConfig extends ClientConfig {
     bzz?: BzzConfig | Bzz;
     pss?: string | Pss;

--- a/packages/swarm-browser/webpack.config.js
+++ b/packages/swarm-browser/webpack.config.js
@@ -5,7 +5,7 @@ const path = require('path')
 const TerserPlugin = require('terser-webpack-plugin')
 const isProduction = process.env.NODE_ENV === 'production'
 
-const main = () => {
+module.exports = () => {
   const envName = isProduction ? 'production' : 'development'
   return {
     bail: isProduction,
@@ -82,31 +82,4 @@ const main = () => {
     },
     stats: 'minimal',
   }
-}
-
-const readable = () => {
-  return {
-    bail: false,
-    mode: 'development',
-    devtool: 'cheap-module-source-map',
-    entry: path.join(__dirname, `..`, '..', 'node_modules', 'readable-stream', 'readable-browser.js'),
-    output: {
-      path: path.join(__dirname, `dist/`),
-      filename: `readable-stream.js`,
-      sourceMapFilename: `readable-stream.js.map`,
-      library: 'NodeStream',
-      libraryTarget: 'umd',
-      devtoolModuleFilenameTemplate: info =>
-        path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
-    },
-    node: {
-      Buffer: true,
-    },
-    target: 'web',
-    stats: 'minimal',
-  }
-}
-
-module.exports = () => {
-  return isProduction ? main() : [main(), readable()]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3793,7 +3793,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3959,11 +3959,6 @@ detect-indent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
   integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -5623,7 +5618,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -7532,15 +7527,6 @@ natural-orderby@^2.0.1:
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
   integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -7637,22 +7623,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.42:
   version "1.1.42"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.42.tgz#a999f6a62f8746981f6da90627a8d2fc090bbad7"
@@ -7744,7 +7714,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
   integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
@@ -7768,7 +7738,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8627,7 +8597,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-rc@^1.2.7, rc@^1.2.8:
+rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -9222,7 +9192,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -9832,7 +9802,7 @@ tar-stream@^2.0.0, tar-stream@^2.1.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Currently when you want to download directory with bigger amount of data (around >300kB, have not searched for exact number) it fails with error `TypeError: This readable stream reader has been released and cannot be used to read from its previous owner stream`. This fix is fixing it. 

I have also exposed `Readable` and `Buffer` as part of the `Swarm` bundle for testing but also for better dev UX for cases when people use the build bundle itself. I have also added some documentation about that.